### PR TITLE
added name in metadata.rb as its a best practise and required by chef…

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,6 +1,7 @@
+name             "silverlight"
 maintainer       "Joshua Timberman"
 maintainer_email "cookbooks@housepub.org"
 license          "Apache 2.0"
 description      "Installs/Configures silverlight"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.5.0"
+version          "0.5.1"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -34,8 +34,7 @@ execute target do
   command %Q(#{target} /q #{node['silverlight']['options'].join(' ')})
   not_if do
     begin
-      require 'win32/registry'
-      Win32::Registry::HKEY_LOCAL_MACHINE.open('Software\Microsoft\Silverlight').keys
+      registry_key_exists?('HKEY_LOCAL_MACHINE\Software\Microsoft\Silverlight')
     rescue
       false
     end


### PR DESCRIPTION
Hi @jtimberman ,

We are using chef-guard (http://xanzy.io/projects/chef-guard/introduction/overview.html) which is is requiring some best practices in order to freeze the cookbooks to an artifact.

Can you except the following pull request so that we are able to freeze this cookbook and use the community version instead of an temporary fork. Next to that can you make sure this version will also be available as 0.5.1 in the chef supermarket https://supermarket.chef.io/cookbooks/silverlight.

Thanks in advance.

Regards,
Jos